### PR TITLE
Disable transparency

### DIFF
--- a/sixel/sixel.py
+++ b/sixel/sixel.py
@@ -24,7 +24,7 @@ def display(figure):
     """ Display figure on stdout as sixel graphic """
     print()
     p = Popen(["convert", "-colors", '16', 'png:-', 'sixel:-'], stdin=PIPE)
-    figure.savefig(p.stdin, bbox_inches="tight", format='png', transparent=True, pad_inches=0.)
+    figure.savefig(p.stdin, bbox_inches="tight", format='png', transparent=False, pad_inches=0.)
     p.stdin.close()
     p.wait()
 


### PR DESCRIPTION
Hi,

Using this backend with https://github.com/maxmahlke/classy/ led to poor quality plots that are practically unreadable.
Setting transparent to False massively improves the situation; see screenshots of the issue at https://github.com/maxmahlke/classy/issues/6 .

I don't know if this is something you want upstream, but I thought to submit a PR in case you do.

Thanks!